### PR TITLE
adding missing logd package to build

### DIFF
--- a/.config
+++ b/.config
@@ -2172,7 +2172,7 @@ CONFIG_PACKAGE_librt=y
 CONFIG_PACKAGE_libssp=y
 CONFIG_PACKAGE_libstdcpp=m
 CONFIG_PACKAGE_libthread-db=m
-# CONFIG_PACKAGE_logd is not set
+CONFIG_PACKAGE_logd=m
 CONFIG_PACKAGE_mtd=y
 CONFIG_PACKAGE_netifd=y
 CONFIG_PACKAGE_om-watchdog=m


### PR DESCRIPTION
as described in the object, we forgot to mark the **logd** package to **=m** so to be part of the build.